### PR TITLE
Update 0.15.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
 upload_channels:
   - sfe1ed40
-channels:
-  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,4 @@ upload_channels:
   - sfe1ed40
 channels:
   - sfe1ed40
+  - https://staging.continuum.io/prefect/fs/umap-learn-feedstock/pr3/52ba27e

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,3 @@ upload_channels:
   - sfe1ed40
 channels:
   - sfe1ed40
-  - https://staging.continuum.io/prefect/fs/umap-learn-feedstock/pr3/8e14b1c

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ upload_channels:
   - sfe1ed40
 channels:
   - sfe1ed40
-  - https://staging.continuum.io/prefect/fs/umap-learn-feedstock/pr3/52ba27e
+  - https://staging.continuum.io/prefect/fs/umap-learn-feedstock/pr3/8e14b1c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True   #[ py<38 or s390x or ppc64le]
+  skip: True  # [py<38 or s390x or ppc64le]
   
   # ppc64le has numerous conflicts within the required
   # dependencies that we will revist at a later time.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.20.0
+    - numpy {{ numpy }}
     - hdbscan >=0.8.29
     - umap-learn >=0.5.0
     - pandas >=1.1.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - wheel
   run:
     - python
+    # To avoid umap-learn/numpy/numba incompatibility we need numpy<1.24
     - numpy >=1.20.0,!=1.22.0,!=1.22.1,!=1.22.2,<1.24
     - hdbscan >=0.8.29
     - umap-learn >=0.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,10 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True   #[ py<38 or s390x]
+  skip: True   #[ py<38 or s390x or ppc64le]
+  
+  # ppc64le has numerous conflicts within the required
+  # dependencies that we will revist at a later time.
 
 requirements:
   host:
@@ -24,7 +27,7 @@ requirements:
     - python
     - numpy >=1.20.0,!=1.22.0,!=1.22.1,!=1.22.2,<1.24
     - hdbscan >=0.8.29
-    - umap-learn 0.5.4
+    - umap-learn >=0.5.0
     - pandas >=1.1.5
     - scikit-learn >=0.22.2.post1
     - tqdm >=4.41.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - setuptools
     - wheel
+    - numpy >={{ numpy_min_ver }},!=1.22.0,!=1.22.1,!=1.22.2,<1.25
   run:
     - python
     - numpy
@@ -30,7 +31,7 @@ requirements:
     - tqdm >=4.41.1
     - sentence-transformers >=0.4.1
     - plotly >=4.7.0
-    - numpy >={{ numpy_min_ver }},!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >={{ numpy_min_ver }},!=1.22.0,!=1.22.1,!=1.22.2,<1.25
+    - numpy >=1.20.0,!=1.22.0,!=1.22.1,!=1.22.2,<1.24
     - hdbscan >=0.8.29
     - umap-learn 0.5.4
     - pandas >=1.1.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - tqdm >=4.41.1
     - sentence-transformers >=0.4.1
     - plotly >=4.7.0
+    - numpy >={{ numpy_min_ver }},!=1.22.0,!=1.22.1,!=1.22.2,<1.25
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bertopic" %}
-{% set version = "0.13.0" %}
+{% set version = "0.15.0" %}
 
 
 package:
@@ -8,31 +8,25 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/bertopic-{{ version }}.tar.gz
-  sha256: 676eb22d729c133be8798458380663003dbcc307efa71e1259df5ebce84d9e6b
-
+  sha256: b7fe931a727e00c00ff42ef974fd63b83621c30a9259ed32fceaa7c934845eaf
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
   run:
-    - python >=3.7
-    # This is a temporary workaround; review in the future
-    - pyyaml <6.0
-    - umap-learn >=0.5.0
-    - hdbscan >=0.8.27
+    - python
     - numpy >=1.20.0
+    - hdbscan >=0.8.29
+    - umap-learn >=0.5.0
     - pandas >=1.1.5
-    - plotly >=4.7.0
     - scikit-learn >=0.22.2.post1
-    - sentence-transformers >=0.4.1
     - tqdm >=4.41.1
-    - cython
-    - pyarrow >=6.0.0
+    - sentence-transformers >=0.4.1
+    - plotly >=4.7.0
 
 test:
   imports:
@@ -47,6 +41,11 @@ about:
   summary: BERTopic performs topic Modeling with state-of-the-art transformer models.
   license: MIT
   license_file: LICENSE
+  description: |
+    BERTopic is a topic modeling technique that leverages transformers and c-TF-IDF to
+    create dense clusters allowing for easily interpretable topics whilst keeping important
+    words in the topic descriptions.
+  doc_url: https://maartengr.github.io/BERTopic/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python
     - numpy
     - hdbscan >=0.8.29
-    - umap-learn >=0.5.0
+    - umap-learn 0.5.4
     - pandas >=1.1.5
     - scikit-learn >=0.22.2.post1
     - tqdm >=4.41.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,10 +20,9 @@ requirements:
     - python
     - setuptools
     - wheel
-    - numpy >={{ numpy_min_ver }},!=1.22.0,!=1.22.1,!=1.22.2,<1.25
   run:
     - python
-    - numpy
+    - numpy >={{ numpy_min_ver }},!=1.22.0,!=1.22.1,!=1.22.2,<1.25
     - hdbscan >=0.8.29
     - umap-learn 0.5.4
     - pandas >=1.1.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
 {% set name = "bertopic" %}
 {% set version = "0.15.0" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/bertopic-{{ version }}.tar.gz
-  sha256: b7fe931a727e00c00ff42ef974fd63b83621c30a9259ed32fceaa7c934845eaf
+  sha256: 96dae6e64b1d9e4ecb65ee97623e7451d00275d53515a3e5fe36adff6f5517e1
+
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: True   #[ py<38 or s390x]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - python
     - numpy >=1.20.0
@@ -42,11 +44,13 @@ about:
   summary: BERTopic performs topic Modeling with state-of-the-art transformer models.
   license: MIT
   license_file: LICENSE
+  license_url: https://github.com/MaartenGr/BERTopic/blob/master/LICENSE
   description: |
     BERTopic is a topic modeling technique that leverages transformers and c-TF-IDF to
     create dense clusters allowing for easily interpretable topics whilst keeping important
     words in the topic descriptions.
   doc_url: https://maartengr.github.io/BERTopic/
+  dev_url: https://maartengr.github.io/BERTopic/changelog.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ about:
   home: https://github.com/MaartenGr/BERTopic
   summary: BERTopic performs topic Modeling with state-of-the-art transformer models.
   license: MIT
-  license_file: LICENSE
+  license_family: MIT
   license_url: https://github.com/MaartenGr/BERTopic/blob/master/LICENSE
   description: |
     BERTopic is a topic modeling technique that leverages transformers and c-TF-IDF to

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy {{ numpy }}
+    - numpy
     - hdbscan >=0.8.29
     - umap-learn >=0.5.0
     - pandas >=1.1.5


### PR DESCRIPTION
# ☆❄️Bertopic 0.15.0 Update ❄️ ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2956)
[Upstream](https://github.com/MaartenGr/BERTopic)
[Dependencies ](https://github.com/MaartenGr/BERTopic/blob/master/setup.py)
## Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- skipped ppc64le due to dependency conflicts that we will revisit later.
- Added `abs.yaml`

## Related dependencies or Issues:
- depends on AnacondaRecipes/umap-learn-feedstock#3

